### PR TITLE
fix: for ssr compliance, don't use window directly

### DIFF
--- a/projects/mat-timepicker/src/lib/hours-clock-dial.ts
+++ b/projects/mat-timepicker/src/lib/hours-clock-dial.ts
@@ -99,6 +99,7 @@ export class MatHoursClockDial implements OnInit {
   }>();
 
   hours: ClockDialViewCell[] = [];
+  _window?: Window;
 
   get disabledHand(): boolean {
     return !this.availableHours.includes(this.selectedHour);
@@ -111,9 +112,12 @@ export class MatHoursClockDial implements OnInit {
   constructor(
     private _element: ElementRef<HTMLElement>,
     private _cdr: ChangeDetectorRef,
-    @Inject(DOCUMENT) private _document: Document,
-    @Inject(Window) private _window: Window
-  ) {}
+    @Inject(DOCUMENT) private _document: Document
+  ) {
+    if (this._document) {
+      this._window = this._document.defaultView as Window;
+    }
+  }
 
   ngOnInit(): void {
     this._initHours();
@@ -179,6 +183,10 @@ export class MatHoursClockDial implements OnInit {
 
   /** Changes selected hour based on coordinates. */
   private _setHour(event: MouseEvent | TouchEvent): void {
+    if (!this._window) {
+      return;
+    }
+
     const element = this._element.nativeElement;
     const elementRect = element.getBoundingClientRect();
     const width = element.offsetWidth;

--- a/projects/mat-timepicker/src/lib/minutes-clock-dial.ts
+++ b/projects/mat-timepicker/src/lib/minutes-clock-dial.ts
@@ -88,6 +88,8 @@ export class MatMinutesClockDial implements OnInit {
 
   minutes: ClockDialViewCell[] = [];
 
+  _window?: Window;
+
   get disabled(): boolean {
     return !this.availableMinutes.includes(this.selectedMinute);
   }
@@ -99,9 +101,12 @@ export class MatMinutesClockDial implements OnInit {
   constructor(
     private _element: ElementRef<HTMLElement>,
     private _cdr: ChangeDetectorRef,
-    @Inject(DOCUMENT) private _document: Document,
-    @Inject(Window) private _window: Window
-  ) {}
+    @Inject(DOCUMENT) private _document: Document
+  ) {
+    if (_document && _document.defaultView instanceof Window) {
+      this._window = _document.defaultView;
+    }
+  }
 
   ngOnInit(): void {
     this._initMinutes();
@@ -162,6 +167,10 @@ export class MatMinutesClockDial implements OnInit {
   }
 
   private _setMinute(event: MouseEvent | TouchEvent): void {
+    if (!this._window) {
+      return;
+    }
+
     const element = this._element.nativeElement;
     const elementRect = element.getBoundingClientRect();
     const width = element.offsetWidth;

--- a/projects/mat-timepicker/src/lib/timepicker.module.ts
+++ b/projects/mat-timepicker/src/lib/timepicker.module.ts
@@ -91,7 +91,7 @@ import { MatTimepickerIntl } from './timepicker-intl';
   providers: [
     MatTimepickerIntl,
     MAT_TIMEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
-    { provide: Window, useValue: window },
+    // { provide: Window, useValue: window },
     { provide: MAT_DEFAULT_ACITONS, useValue: MatTimepickerDefaultActions },
     {
       provide: MAT_FAB_DEFAULT_OPTIONS,


### PR DESCRIPTION
Hello,

In order to be SSR (server prerendering) compliant, could you make the "Window" usage optional ? With the new Angular 17 "standalone" (no module) architecture, I couldn't find a way to override the problematic components only in server mode, because of the "direct reference" to "window" object in your main module, as soon as I import it, the compiler just won't take it ...

![image](https://github.com/dhutaryan/ngx-mat-timepicker/assets/2862295/c442a23e-8243-4e56-bbf7-6d457afaf212)

So I finally thought I'd try editing your cool lib :) My solution is not the best or really efficient (and I don't want to make your code look less clean), so I thought I'd just post this PR to suggest the change, but let you do the real job, if you find some time, and if you don't mind .. :D

Thanks in advance.